### PR TITLE
refactor: Improve title hierarchy and consistency on Configuration page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # warzone_easter_egg_helpers
 A collection of web-based utilities to assist with the completion of Call of Duty Warzone easter eggs.
+
+[Open Warzone Easter Egg Helpers web app](https://koen-mulder.github.io/warzone_easter_egg_helpers/)

--- a/city_hall_metro_easter_egg/index.html
+++ b/city_hall_metro_easter_egg/index.html
@@ -47,6 +47,7 @@
             border-radius: 4px;
             cursor: pointer;
             font-size: 0.9em;
+            white-space: nowrap; /* Added to prevent text wrapping */
         }
         #app-header button:disabled {
             background-color: #aaa;
@@ -178,6 +179,54 @@
             border: 1px solid #ccc;
             flex-grow: 1;
             min-width: 150px; /* Ensure select is usable */
+        }
+
+        /* Roman Numeral Button Input Styling */
+        .roman-numeral-item .roman-numeral-details {
+            /* Ensure this container can accommodate button groups if not already flexible */
+            display: flex; /* Already there, good */
+            align-items: center; /* Already there, good */
+            gap: 10px; /* Already there, good */
+        }
+
+        .roman-numeral-item .roman-numeral-details label {
+            font-weight: bold;
+            margin-right: 5px; /* Already there */
+            flex-shrink: 0; /* Already there */
+            /* Consider adjusting flex-basis or width if button groups make lines too long */
+            /* For now, existing label style should be okay */
+        }
+
+        .roman-button-group {
+            display: flex;
+            flex-wrap: wrap; /* Allow buttons to wrap if many options */
+            gap: 10px; /* Spacing between buttons */
+            flex-grow: 1;
+            justify-content: flex-start; /* Align buttons to the start */
+        }
+
+        .roman-numeral-btn {
+            padding: 10px 15px;
+            font-size: 1.1em;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            background-color: #f0f0f0;
+            cursor: pointer;
+            transition: background-color 0.2s, border-color 0.2s;
+            min-width: 50px; /* Ensure a decent tap target */
+            text-align: center;
+        }
+
+        .roman-numeral-btn:hover {
+            background-color: #e0e0e0;
+            border-color: #bbb;
+        }
+
+        .roman-numeral-btn.selected {
+            background-color: #007bff;
+            color: white;
+            border-color: #0056b3;
+            font-weight: bold;
         }
 
         /* Modifier selection styling */
@@ -327,7 +376,152 @@
                 font-size: 1em;
                 min-width: 40px;
             }
+            /* Roman Numeral Buttons Responsive */
+            .roman-numeral-btn {
+                padding: 8px 10px;
+                font-size: 1em;
+                min-width: 40px;
+            }
+            .roman-button-group {
+                gap: 8px;
+            }
         }
+
+        /* Configuration Page Sections */
+        .config-section {
+            margin-top: 20px;
+            margin-bottom: 20px;
+            padding-top: 15px;
+            border-top: 1px solid #eee;
+        }
+
+        .config-section h4 {
+            margin-top: 0;
+            margin-bottom: 10px;
+            color: #333;
+        }
+
+        .config-option {
+            display: flex;
+            align-items: center;
+            margin-bottom: 8px;
+        }
+
+        .config-option input[type="radio"] {
+            margin-right: 8px;
+            cursor: pointer;
+        }
+
+        .config-option label {
+            cursor: pointer;
+        }
+
+        /* Config Page Styles */
+        #config-btn {
+            background-color: #0056b3;
+            color: white;
+            border: none;
+            padding: 8px 12px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 1.1em; /* Adjusted to match other header buttons better */
+            margin-left: 5px; /* Added for spacing */
+            margin-right: 5px; /* Added for spacing */
+        }
+        #config-btn:disabled {
+            background-color: #aaa;
+            cursor: not-allowed;
+        }
+
+        #config-page {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: #fff;
+            z-index: 1100;
+            overflow-y: auto;
+            display: none; /* Initially hidden, JS will toggle */
+        }
+
+        #config-page-content {
+            max-width: 600px;
+            margin: 20px auto;
+            padding: 20px;
+            background-color: #f9f9f9;
+            border-radius: 8px;
+            box-shadow: 0 0 15px rgba(0,0,0,0.2);
+        }
+        
+        #config-page-content h2 {
+            text-align: center;
+            color: #333;
+            margin-bottom: 20px;
+        }
+
+        #painting-config-inputs {
+            display: flex;
+            flex-direction: column;
+            gap: 15px;
+            margin-bottom: 20px;
+        }
+
+        #painting-config-inputs div { /* Style for each dynamically generated input row */
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        #painting-config-inputs label {
+            flex-basis: 120px; /* Adjust as needed */
+            font-weight: bold;
+        }
+
+        #painting-config-inputs input[type="text"] {
+            flex-grow: 1;
+            padding: 8px;
+            border-radius: 4px;
+            border: 1px solid #ccc;
+            font-size: 1em;
+        }
+
+        #save-config-btn, #reset-config-btn, #close-config-btn {
+            display: block;
+            width: 100%;
+            margin-bottom: 10px;
+            padding: 12px;
+            border-radius: 5px;
+            border: none;
+            cursor: pointer;
+            font-size: 1em;
+            text-align: center;
+        }
+
+        #save-config-btn {
+            background-color: #28a745; /* Green */
+            color: white;
+        }
+        #save-config-btn:hover {
+            background-color: #218838;
+        }
+
+        #reset-config-btn {
+            background-color: #ffc107; /* Yellow */
+            color: #333;
+        }
+        #reset-config-btn:hover {
+            background-color: #e0a800;
+        }
+
+        #close-config-btn {
+            background-color: #6c757d; /* Gray */
+            color: white;
+        }
+        #close-config-btn:hover {
+            background-color: #5a6268;
+        }
+
     </style>
 </head>
 <body>
@@ -335,6 +529,7 @@
         <header id="app-header">
             <button id="prev-step-btn">< Back</button>
             <h2 id="step-title">Step Title</h2>
+            <button id="config-btn">&#x1F6E0;</button>
             <button id="next-step-btn">Next ></button>
         </header>
         <main id="step-content">
@@ -345,6 +540,40 @@
         </footer>
     </div>
 
+    <div id="config-page" style="display: none;">
+        <div id="config-page-content">
+            <h2>Configuration</h2>
+            <div class="config-section"> <!-- New wrapper div -->
+                <h4>Painting Names</h4>
+                <div id="painting-config-inputs">
+                    <!-- Input fields will be dynamically added here by JavaScript later -->
+                    <!-- Example for one painting (for structure reference, JS will generate these):
+                <div>
+                    <label for="config-painting-horse">Horse:</label>
+                    <input type="text" id="config-painting-horse" data-painting-id="Horse">
+                </div>
+                -->
+                </div>
+            </div>
+
+            <div class="config-section">
+                <h4>Roman Numeral Input Style</h4>
+                <div class="config-option">
+                    <input type="radio" id="roman-input-dropdown" name="romanInputStyle" value="dropdown" checked>
+                    <label for="roman-input-dropdown">Dropdown List</label>
+                </div>
+                <div class="config-option">
+                    <input type="radio" id="roman-input-buttons" name="romanInputStyle" value="buttons">
+                    <label for="roman-input-buttons">Buttons</label>
+                </div>
+            </div>
+
+            <button id="save-config-btn">Save Configuration</button>
+            <button id="reset-config-btn">Reset to Default</button>
+            <button id="close-config-btn">Close</button>
+        </div>
+    </div>
+
     <div id="image-modal" class="modal">
         <span class="modal-close-btn" id="modal-close-btn">×</span>
         <img class="modal-content" id="modal-img-src">
@@ -353,6 +582,7 @@
     <script>
         const MAX_STEPS = 12;
         let currentStep = 1;
+        let currentRomanInputStyle = 'dropdown'; // Default value
 
         // Data for selections
         let appData = {
@@ -367,9 +597,15 @@
             modifier4_value: null,
         };
 
-        const PICTURE_DATA = [
-            { name: "Horse" }, { name: "House" }, { name: "Snow" }, { name: "Tree" },
-            { name: "Boat" }, { name: "River" }, { name: "Owl" }, { name: "Lamb chop" }
+        let PICTURE_DATA = [ // Changed to let
+            { id: "Horse", defaultName: "Horse", displayName: "Horse" },
+            { id: "House", defaultName: "House", displayName: "House" },
+            { id: "Snow", defaultName: "Snow", displayName: "Snow" },
+            { id: "Tree", defaultName: "Tree", displayName: "Tree" },
+            { id: "Boat", defaultName: "Boat", displayName: "Boat" },
+            { id: "River", defaultName: "River", displayName: "River" },
+            { id: "Owl", defaultName: "Owl", displayName: "Owl" },
+            { id: "Lamb chop", defaultName: "Lamb chop", displayName: "Lamb chop" }
         ];
 
         const ROMAN_NUMERAL_OPTIONS = [
@@ -384,8 +620,12 @@
 
         // DOM Elements
         let stepTitleElement, stepContentElement, prevStepBtn, nextStepBtn, restartBtn, imageModal, modalImg, modalCloseBtn;
+        let configBtn, configPage, closeConfigBtn, appContainer; // Added new elements
+        let paintingConfigInputsContainer, saveConfigBtn, resetConfigBtn; // Added reset button
 
         document.addEventListener('DOMContentLoaded', () => {
+            loadCustomNames(); // Load custom names first
+
             stepTitleElement = document.getElementById('step-title');
             stepContentElement = document.getElementById('step-content');
             prevStepBtn = document.getElementById('prev-step-btn');
@@ -394,6 +634,14 @@
             imageModal = document.getElementById('image-modal');
             modalImg = document.getElementById('modal-img-src');
             modalCloseBtn = document.getElementById('modal-close-btn');
+            appContainer = document.getElementById('app-container'); // Ensure appContainer is selected
+
+            configBtn = document.getElementById('config-btn');
+            configPage = document.getElementById('config-page');
+            closeConfigBtn = document.getElementById('close-config-btn');
+            paintingConfigInputsContainer = document.getElementById('painting-config-inputs');
+            saveConfigBtn = document.getElementById('save-config-btn'); 
+            resetConfigBtn = document.getElementById('reset-config-btn'); // Select the reset button
 
             prevStepBtn.addEventListener('click', goPrevStep);
             nextStepBtn.addEventListener('click', goNextStep);
@@ -406,10 +654,179 @@
             });
             
             renderCurrentStep();
+
+            if(configBtn) {
+                configBtn.addEventListener('click', showConfigPage);
+            }
+            if(closeConfigBtn) {
+                closeConfigBtn.addEventListener('click', hideConfigPage);
+            }
+            if(saveConfigBtn) { 
+                saveConfigBtn.addEventListener('click', saveCustomNames);
+            }
+            if(resetConfigBtn) { // Add event listener for reset button
+                resetConfigBtn.addEventListener('click', resetCustomNamesToDefault);
+            }
         });
 
-        function getPictureImageSrc(pictureName, type) {
+        // New functions for config page visibility
+        function showConfigPage() {
+            if(appContainer) appContainer.style.display = 'none';
+            if(configPage) configPage.style.display = 'block';
+            populateConfigInputs(); // Populate/refresh inputs each time config page is shown
+        }
+
+        function hideConfigPage() {
+            if(configPage) configPage.style.display = 'none';
+            if(appContainer) appContainer.style.display = 'flex'; // app-container uses flex
+            renderCurrentStep(); // Re-render main view when config is closed to reflect changes
+        }
+
+        function saveCustomNames() {
+            const customNamesToStore = {};
+            let namesChanged = false; // Specifically for painting names
+
+            // Select all relevant input fields from the config page
+            const inputElements = document.querySelectorAll('#painting-config-inputs input[type="text"]');
+
+            inputElements.forEach(inputElement => {
+                const paintingId = inputElement.dataset.paintingId;
+                const newDisplayName = inputElement.value.trim();
+                
+                const picture = PICTURE_DATA.find(p => p.id === paintingId);
+                if (picture) {
+                    let finalName = newDisplayName || picture.defaultName; // Use default if input is empty
+
+                    if (picture.displayName !== finalName) {
+                        picture.displayName = finalName;
+                        namesChanged = true;
+                    }
+                    customNamesToStore[picture.id] = picture.displayName;
+                }
+            });
+
+            if (namesChanged) {
+                localStorage.setItem('customPaintingNames', JSON.stringify(customNamesToStore));
+            }
+
+            // Save Roman Numeral Input Style
+            const selectedStyleElement = document.querySelector('input[name="romanInputStyle"]:checked');
+            let styleChanged = false;
+            if (selectedStyleElement) {
+                if (currentRomanInputStyle !== selectedStyleElement.value) {
+                    currentRomanInputStyle = selectedStyleElement.value;
+                    styleChanged = true;
+                }
+                localStorage.setItem('romanNumeralInputStyle', currentRomanInputStyle);
+            }
+
+            if (namesChanged && styleChanged) {
+                alert('Painting names and input style saved!');
+            } else if (namesChanged) {
+                alert('Painting names saved!');
+            } else if (styleChanged) {
+                alert('Roman numeral input style saved!');
+            } else {
+                alert('No changes detected.');
+            }
+
+            // Refresh the input fields to show trimmed values or reverted defaults
+            populateConfigInputs(); 
+            
+            // Changes will be reflected when user navigates or closes config (due to renderCurrentStep in hideConfigPage)
+        }
+
+        function resetCustomNamesToDefault() {
+            const confirmReset = confirm("Are you sure you want to reset all painting names and input style to their defaults? This cannot be undone.");
+            if (confirmReset) {
+                // Clear the custom names from localStorage
+                localStorage.removeItem('customPaintingNames');
+                // Reset displayName for each painting in PICTURE_DATA back to its defaultName
+                PICTURE_DATA.forEach(pic => {
+                    pic.displayName = pic.defaultName;
+                });
+
+                // Reset Roman Numeral Input Style
+                currentRomanInputStyle = 'dropdown'; // Reset to default
+                localStorage.setItem('romanNumeralInputStyle', currentRomanInputStyle);
+
+                // Repopulate the input fields on the configuration page to show the defaults
+                populateConfigInputs();
+
+                alert('Configuration has been reset to default.');
+
+                // Similar to saving, if the main app view needs immediate refresh:
+                // The hideConfigPage function (if it calls renderCurrentStep) will handle this
+                // when the user closes the config page.
+            }
+        }
+
+        function loadCustomNames() { // Renamed in thought, but keeping as loadCustomNames for simplicity as per prompt
+            // Load Painting Names
+            const storedNames = localStorage.getItem('customPaintingNames');
+            if (storedNames) {
+                try {
+                    const customNames = JSON.parse(storedNames);
+                    PICTURE_DATA.forEach(pic => {
+                        if (customNames[pic.id]) {
+                            pic.displayName = customNames[pic.id];
+                        } else {
+                            pic.displayName = pic.defaultName;
+                        }
+                    });
+                } catch (e) {
+                    console.error("Error parsing custom painting names from localStorage:", e);
+                    PICTURE_DATA.forEach(pic => pic.displayName = pic.defaultName);
+                }
+            } else {
+                PICTURE_DATA.forEach(pic => pic.displayName = pic.defaultName);
+            }
+
+            // Load Roman Numeral Input Style
+            const savedRomanInputStyle = localStorage.getItem('romanNumeralInputStyle');
+            if (savedRomanInputStyle && (savedRomanInputStyle === 'dropdown' || savedRomanInputStyle === 'buttons')) {
+                currentRomanInputStyle = savedRomanInputStyle;
+            } else {
+                currentRomanInputStyle = 'dropdown'; // Default if nothing valid is stored
+                localStorage.setItem('romanNumeralInputStyle', currentRomanInputStyle); // Optional: store default
+            }
+        }
+
+        function populateConfigInputs() {
+            if (!paintingConfigInputsContainer) return;
+            paintingConfigInputsContainer.innerHTML = ''; // Clear any existing inputs
+
+            PICTURE_DATA.forEach(pic => {
+                const inputDiv = document.createElement('div');
+                // inputDiv.className = 'config-input-item'; // Using existing #painting-config-inputs div styles
+
+                const label = document.createElement('label');
+                label.htmlFor = `config-painting-${pic.id.replace(/ /g, '_')}`;
+                label.textContent = `${pic.defaultName}:`; // Label with default name for clarity
+
+                const input = document.createElement('input');
+                input.type = 'text';
+                input.id = `config-painting-${pic.id.replace(/ /g, '_')}`;
+                input.dataset.paintingId = pic.id; // Store original ID for saving
+                input.value = pic.displayName; // Set current display name
+
+                inputDiv.appendChild(label);
+                inputDiv.appendChild(input);
+                paintingConfigInputsContainer.appendChild(inputDiv);
+            });
+
+            // Set radio buttons for Roman numeral input style
+            if (currentRomanInputStyle === 'buttons') {
+                document.getElementById('roman-input-buttons').checked = true;
+            } else {
+                document.getElementById('roman-input-dropdown').checked = true; // Default
+            }
+        }
+
+        function getPictureImageSrc(pictureName, type) { // pictureName here is actually picture.id
             if (!pictureName) return ""; // Or a placeholder
+            // Currently, pictureName is expected to be the 'id' (original name) from PICTURE_DATA
+            // This will be updated later if necessary to distinguish between id and displayName for image paths
             return `images/${pictureName.toLowerCase().replace(/ /g, '_')}_${type}.PNG`;
         }
         
@@ -463,8 +880,6 @@
 
             if (currentStep === MAX_STEPS) {
                 nextStepBtn.disabled = true;
-            } else if (currentStep === 1 || currentStep === 2) { // Steps with on-page buttons for next
-                nextStepBtn.disabled = true;
             } else if (currentStep >= 3 && currentStep <= 6) { // Painting selection steps
                 const paintingKey = `painting${currentStep - 2}_picture`;
                 nextStepBtn.disabled = !appData[paintingKey];
@@ -504,15 +919,15 @@
             switch (currentStep) {
                 case 1: title = "Workflow"; renderStep1(); break;
                 case 2: title = "Lockdown"; renderStep2(); break;
-                case 3: title = "Painting 1: Select painting"; renderPaintingSelectionStep(1); break;
-                case 4: title = "Painting 2: Select painting"; renderPaintingSelectionStep(2); break;
-                case 5: title = "Painting 3: Select painting"; renderPaintingSelectionStep(3); break;
-                case 6: title = "Painting 4: Select painting"; renderPaintingSelectionStep(4); break;
+                case 3: title = "Select painting 1"; renderPaintingSelectionStep(1); break;
+                case 4: title = "Select painting 2"; renderPaintingSelectionStep(2); break;
+                case 5: title = "Select painting 3"; renderPaintingSelectionStep(3); break;
+                case 6: title = "Select painting 4"; renderPaintingSelectionStep(4); break;
                 case 7: title = "Roman numerals"; renderRomanNumeralsStep(); break;
-                case 8: title = "Modifier painting 1: Select modifier"; renderModifierSelectionStep(1); break;
-                case 9: title = "Modifier painting 2: Select modifier"; renderModifierSelectionStep(2); break;
-                case 10: title = "Modifier painting 3: Select modifier"; renderModifierSelectionStep(3); break;
-                case 11: title = "Modifier painting 4: Select modifier"; renderModifierSelectionStep(4); break;
+                case 8: title = "Select modifier 1"; renderModifierSelectionStep(1); break;
+                case 9: title = "Select modifier 2"; renderModifierSelectionStep(2); break;
+                case 10: title = "Select modifier 3"; renderModifierSelectionStep(3); break;
+                case 11: title = "Select modifier 4"; renderModifierSelectionStep(4); break;
                 case 12: title = "Result"; renderResultStep(); break;
             }
             stepTitleElement.textContent = title;
@@ -524,14 +939,15 @@
         function renderStep1() {
             stepContentElement.innerHTML = `
                 <h3>Workflow Explanation</h3>
-                <ul>
-                    <li>Step 1: Workflow explanation (this step)</li>
-                    <li>Step 2: Unlock the computer using keypad</li>
-                    <li>Step 3 - 6: Open the computer and select paintings that are shown on the computer</li>
-                    <li>Step 7: Run around and note the roman numerals underneath the 4 paintings</li>
-                    <li>Step 8 - 11: Open the computer again and select the modifier belonging to each painting</li>
-                    <li>Step 12: Input the resulting code shown at the end of this form</li>
-                </ul>
+                <ol>
+                    <li><strong>Understand the Workflow:</strong> (This is the current step you are reading).</li>
+                    <li><strong>Secure and Access:</strong> Lockdown the building, then unlock the computer using the keypad.</li>
+                    <li><strong>Select Paintings:</strong> Access the computer and select the paintings displayed on the screen.</li>
+                    <li><strong>Find Roman Numerals:</strong> Locate the four physical paintings you selected and note the Roman numeral beneath each one.</li>
+                    <li><strong>Select Modifiers:</strong> Return to the computer and select the modifiers that are displayed after each of the four paintings.</li>
+                    <li><strong>Escape:</strong> Input the final code (which will be displayed on the computer). Then, quickly head to the metro station.</li>
+                </ol>
+                <p><strong>Note:</strong> You can customize painting names in the configuration settings to match terms you're familiar with.</p>
                 <button class="action-button" id="step1-next">Yeah yeah, I know, NEXT!!</button>
             `;
             document.getElementById('step1-next').addEventListener('click', () => goNextStep());
@@ -551,11 +967,11 @@
             const appDataKey = `painting${paintingNum}_picture`;
             let gridHtml = '<div class="picture-grid">';
             PICTURE_DATA.forEach(pic => {
-                const isSelected = appData[appDataKey] === pic.name;
+                const isSelected = appData[appDataKey] === pic.id; // Use pic.id for data storage
                 gridHtml += `
-                    <div class="picture-item ${isSelected ? 'selected' : ''}" data-picture-name="${pic.name}">
-                        <img src="${getPictureImageSrc(pic.name, 'screen')}" alt="${pic.name} screen version">
-                        <span>${pic.name}</span>
+                    <div class="picture-item ${isSelected ? 'selected' : ''}" data-picture-id="${pic.id}">
+                        <img src="${getPictureImageSrc(pic.id, 'screen')}" alt="${pic.displayName} screen version">
+                        <span>${pic.displayName}</span>
                     </div>
                 `;
             });
@@ -564,7 +980,7 @@
 
             document.querySelectorAll('.picture-item').forEach(item => {
                 item.addEventListener('click', () => {
-                    appData[appDataKey] = item.dataset.pictureName;
+                    appData[appDataKey] = item.dataset.pictureId; // Store pic.id
                     // Re-render to update selection visuals and then auto-advance
                     renderCurrentStep(); // This updates selection class
                     if (currentStep < 7) { // Auto-advance from painting steps to next or Roman Numerals
@@ -579,52 +995,128 @@
             const uniquePictures = getUniqueSelectedPictures();
             if (uniquePictures.length === 0) {
                 stepContentElement.innerHTML = "<p>No pictures selected yet. Please select pictures in Painting 1-4 steps.</p>";
+                updateNavigationButtonsState(); // Ensure nav is updated even if no pictures
                 return;
             }
 
             let html = '';
-            uniquePictures.forEach(picName => {
-                const screenSrc = getPictureImageSrc(picName, 'screen');
-                const paintingSrc = getPictureImageSrc(picName, 'painting');
-                const currentRomanValue = appData.romanNumerals[picName] || null;
+            uniquePictures.forEach(picId => { // Changed variable name for clarity
+                const picData = PICTURE_DATA.find(p => p.id === picId);
+                if (!picData) return; // Should not happen if uniquePictures is derived correctly
+
+                const displayName = picData.displayName;
+                const screenSrc = getPictureImageSrc(picId, 'screen');
+                const paintingSrc = getPictureImageSrc(picId, 'painting');
+                const currentRomanValue = appData.romanNumerals[picId] || null;
 
                 html += `
-                    <div class="roman-numeral-item">
+                    <div class="roman-numeral-item" data-picture-id="${picId}">
                         <div class="roman-numeral-images">
-                            <img src="${screenSrc}" alt="${picName} screen">
-                            <img src="${paintingSrc}" alt="${picName} painting" class="painting-image-preview" data-painting-src="${paintingSrc}">
+                            <img src="${screenSrc}" alt="${displayName} screen">
+                            <img src="${paintingSrc}" alt="${displayName} painting" class="painting-image-preview" data-painting-src="${paintingSrc}">
                         </div>
                         <div class="roman-numeral-details">
-                            <label for="roman-${picName.replace(/ /g, '_')}">${picName}:</label>
-                            <select id="roman-${picName.replace(/ /g, '_')}" data-picture-name="${picName}">
-                                ${ROMAN_NUMERAL_OPTIONS.map(opt => 
-                                    `<option value="${opt.value}" ${opt.value === currentRomanValue ? 'selected' : ''}>${opt.text}</option>`
-                                ).join('')}
-                            </select>
-                        </div>
-                    </div>
-                `;
+                            <label for="roman-input-${picId.replace(/ /g, '_')}">${displayName}:</label>`; // Changed label 'for' to be more generic initially
+
+                if (currentRomanInputStyle === 'buttons') {
+                    html += `<div class="roman-button-group" id="roman-input-${picId.replace(/ /g, '_')}">`;
+                    ROMAN_NUMERAL_OPTIONS.forEach(opt => {
+                        if (opt.value === null) return; // Skip "Select Roman Numeral"
+                        const isSelected = opt.value === currentRomanValue;
+                        const romanNumeralChar = opt.text.split(' ')[0]; // e.g., "V"
+                        const numericValue = opt.value; // e.g., 5
+                        html += `<button class="roman-numeral-btn ${isSelected ? 'selected' : ''}" 
+                                         data-picture-id="${picId}" 
+                                         data-value="${numericValue}">
+                                         <span style="font-weight:bold;">${romanNumeralChar}</span> <span style="color: #555555;">(${numericValue})</span>
+                                 </button>`;
+                    });
+                    html += `</div>`;
+                } else { // Default to dropdown
+                    html += `<select class="roman-numeral-select" id="roman-input-${picId.replace(/ /g, '_')}" data-picture-id="${picId}">`; // Added class for easier selection
+                    ROMAN_NUMERAL_OPTIONS.forEach(opt => {
+                        html += `<option value="${opt.value === null ? '' : opt.value}" ${opt.value === currentRomanValue ? 'selected' : ''}>${opt.text}</option>`;
+                    });
+                    html += `</select>`;
+                }
+                html += `   </div> <!-- closes roman-numeral-details -->
+                        </div> <!-- closes roman-numeral-item -->`;
             });
+
             stepContentElement.innerHTML = html;
 
-            document.querySelectorAll('.roman-numeral-details select').forEach(select => {
-                select.addEventListener('change', (event) => {
-                    const selectedPicName = event.target.dataset.pictureName;
-                    const value = event.target.value === "null" ? null : parseInt(event.target.value);
-                    appData.romanNumerals[selectedPicName] = value;
-                    updateNavigationButtonsState(); // Update nav immediately
-                    
-                    if (areAllRomanNumeralsAssigned()) {
-                        setTimeout(goNextStep, 100); // Auto-advance if all assigned
-                    }
-                });
-            });
-            
+            // Attach common event listeners
             document.querySelectorAll('.painting-image-preview').forEach(img => {
                 img.addEventListener('click', (event) => {
                     openModal(event.target.dataset.paintingSrc);
                 });
             });
+
+            // Attach specific event listeners based on input style
+            if (currentRomanInputStyle === 'buttons') {
+                document.querySelectorAll('.roman-numeral-btn').forEach(button => {
+                    button.addEventListener('click', handleRomanNumeralButtonClick); // This function will be created in next step
+                });
+            } else {
+                document.querySelectorAll('.roman-numeral-select').forEach(select => { // Target by new class
+                    select.addEventListener('change', (event) => {
+                        const selectedPicId = event.target.dataset.pictureId; // Changed to pictureId
+                        const value = event.target.value === "" ? null : parseInt(event.target.value);
+                        appData.romanNumerals[selectedPicId] = value;
+                        updateNavigationButtonsState();
+                        if (areAllRomanNumeralsAssigned()) {
+                            setTimeout(goNextStep, 100);
+                        }
+                    });
+                });
+            }
+            updateNavigationButtonsState(); // Call once after setup
+        }
+
+        function handleRomanNumeralButtonClick(event) {
+            const clickedButton = event.currentTarget; 
+            const picId = clickedButton.dataset.pictureId;
+            const value = parseInt(clickedButton.dataset.value);
+
+            if (!picId || isNaN(value)) {
+                console.error("Button click error: Missing pictureId or value", clickedButton.dataset);
+                return;
+            }
+
+            // Update appData
+            appData.romanNumerals[picId] = value;
+
+            // Update button visual selection within the same group
+            const buttonGroupId = `roman-input-${picId.replace(/ /g, '_')}`;
+            const buttonGroup = document.getElementById(buttonGroupId);
+
+            if (buttonGroup) {
+                const buttonsInGroup = buttonGroup.querySelectorAll('.roman-numeral-btn');
+                buttonsInGroup.forEach(btn => {
+                    if (btn === clickedButton) {
+                        btn.classList.add('selected');
+                    } else {
+                        btn.classList.remove('selected');
+                    }
+                });
+            } else {
+                // Fallback/alternative if direct parent traversal is preferred and structure is known
+                // This assumes the button group is the direct parent. Adjust if structure is different.
+                // console.warn("Button group not found by ID, trying parent traversal for:", picId);
+                // const parentGroup = clickedButton.parentElement;
+                // if (parentGroup && parentGroup.classList.contains('roman-button-group')) {
+                //     parentGroup.querySelectorAll('.roman-numeral-btn').forEach(btn => {
+                //         btn.classList.remove('selected');
+                //     });
+                //     clickedButton.classList.add('selected');
+                // }
+            }
+            
+            // Update navigation and potentially auto-advance
+            updateNavigationButtonsState();
+            if (areAllRomanNumeralsAssigned()) {
+                setTimeout(goNextStep, 100);
+            }
         }
         
         function openModal(imageSrc) {
@@ -641,14 +1133,19 @@
         function renderModifierSelectionStep(modifierNum) {
             const paintingKey = `painting${modifierNum}_picture`;
             const modifierKey = `modifier${modifierNum}_value`;
-            const selectedPictureName = appData[paintingKey];
+            const selectedPictureId = appData[paintingKey]; // This is an ID
 
-            if (!selectedPictureName) {
+            if (!selectedPictureId) {
                 stepContentElement.innerHTML = `<p>No painting selected for Painting ${modifierNum}. Please go back and select one.</p>`;
                 return;
             }
+            const picData = PICTURE_DATA.find(p => p.id === selectedPictureId);
+            if (!picData) {
+                stepContentElement.innerHTML = `<p>Error: Painting data not found for ID ${selectedPictureId}.</p>`;
+                return;
+            }
 
-            const screenSrc = getPictureImageSrc(selectedPictureName, 'screen');
+            const screenSrc = getPictureImageSrc(picData.id, 'screen');
             const currentModifier = appData[modifierKey];
 
             let modifierButtonsHtml = '<div class="modifier-groups">';
@@ -676,8 +1173,8 @@
 
             stepContentElement.innerHTML = `
                 <div class="modifier-display-painting">
-                    <img src="${screenSrc}" alt="${selectedPictureName} screen">
-                    <p>${selectedPictureName}</p>
+                    <img src="${screenSrc}" alt="${picData.displayName} screen">
+                    <p>${picData.displayName}</p>
                 </div>
                 ${modifierButtonsHtml}
             `;
@@ -701,10 +1198,12 @@
             if (!appData.painting3_picture) missingInfo.push("Painting 3 selection");
             if (!appData.painting4_picture) missingInfo.push("Painting 4 selection");
 
-            const uniquePictures = getUniqueSelectedPictures();
-            uniquePictures.forEach(pic => {
-                if (appData.romanNumerals[pic] === undefined || appData.romanNumerals[pic] === null) {
-                    missingInfo.push(`Roman numeral for ${pic}`);
+            const uniquePictures = getUniqueSelectedPictures(); // This returns array of IDs
+            uniquePictures.forEach(picId => {
+                const picData = PICTURE_DATA.find(p => p.id === picId);
+                const displayName = picData ? picData.displayName : picId; // Fallback to ID if not found (should not happen)
+                if (appData.romanNumerals[picId] === undefined || appData.romanNumerals[picId] === null) {
+                    missingInfo.push(`Roman numeral for ${displayName}`);
                 }
             });
             
@@ -734,13 +1233,16 @@
             let breakdownHtml = "<h3>Calculation Breakdown:</h3><ul>";
 
             for (let i = 1; i <= 4; i++) {
-                const pictureName = appData[`painting${i}_picture`];
-                const modifierValue = appData[`modifier${i}_value`];
-                const romanNumeralValue = appData.romanNumerals[pictureName];
+                const pictureId = appData[`painting${i}_picture`]; // This is an ID
+                const picData = PICTURE_DATA.find(p => p.id === pictureId);
+                const displayName = picData ? picData.displayName : pictureId; // Fallback to ID
 
-                if (pictureName === null || modifierValue === null || romanNumeralValue === null || romanNumeralValue === undefined) {
+                const modifierValue = appData[`modifier${i}_value`];
+                const romanNumeralValue = appData.romanNumerals[pictureId];
+
+                if (pictureId === null || modifierValue === null || romanNumeralValue === null || romanNumeralValue === undefined) {
                     // This check is a safeguard; primary check is `missingInfo` above.
-                    stepContentElement.innerHTML = `<p>Error: Data inconsistency for item ${i}. Please review previous steps.</p>`;
+                    stepContentElement.innerHTML = `<p>Error: Data inconsistency for item ${i} (${displayName}). Please review previous steps.</p>`;
                     return;
                 }
                 
@@ -752,8 +1254,7 @@
 
                 breakdownHtml += `
                     <li>
-                        Digit ${i} (<strong>${pictureName}</strong>, Mod ${modifierText}, Roman ${romanNumeralText}):
-                        ${romanNumeralText} (${romanNumeralValue}) ${modifierValue < 0 ? '-' : '+'} ${Math.abs(modifierValue)} = <strong>${resultDigit}</strong>
+                        Digit ${i} (${displayName}: ${romanNumeralText}, ${modifierText}): ${romanNumeralValue} ${modifierValue < 0 ? '-' : '+'} ${Math.abs(modifierValue)} = <strong>${resultDigit}</strong>
                     </li>`;
             }
             breakdownHtml += "</ul>";


### PR DESCRIPTION
This commit refactors the titles on the Configuration page for better structure and clarity:

1.  **Main Title:**
    -   The main title of the configuration page (previously "Configure Painting Names") has been changed to "Configuration".

2.  **Sub-titles:**
    -   A new sub-title "Painting Names" (as an `<h4>`) has been added above the section where you configure painting names.
    -   The "Painting Names" section and the existing "Roman Numeral Input Style" section are now both structured within `<div class="config-section">`. This ensures their respective `<h4>` sub-titles receive consistent styling from the existing CSS rule `.config-section h4`.

3.  **Visual Hierarchy:**
    -   These changes establish a clear visual hierarchy:
        -   Main "Configuration" title (`<h2>`).
        -   Uniformly styled sub-titles for "Painting Names" and "Roman Numeral Input Style" (`<h4>` within `.config-section`).
        -   These sub-titles are visually distinct from the main title and from the labels for individual input fields.
    -   No new CSS rules were required; the existing styles were leveraged by restructuring the HTML.